### PR TITLE
Add configuration field to customize the JIRA issue summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ settings:
   label_mapping:
     enhancement: Story
 
-  # (Optional) JIRA issue's summary customization
-  # Allow to define the JIRA issue's summary and eventually format it with the values
-  # of the GH issue variable.
-  # See GH issue definition : https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28
+  # (Optional) JIRA issue's summary
+  # This field can be used to customize the JIRA issue's summary (title).
+  # The value of the field will be passed to the python
+  # format() method to generate the JIRA summary. The GH issue
+  # variable will be captured in the format() method so that users can
+  # use GH issue attribute's values to build the JIRA summary.
+  # See GH issue definition :
+  # https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28
   #
   # Examples:
   # to use fixed title "github issue": "github issue"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ settings:
   # If label on the issue is not in specified list, this issue will be created as a Bug
   label_mapping:
     enhancement: Story
+
+  # (Optional) JIRA issue summary customization
+  # Allow to define the JIRA issue summary and eventually format it with the values
+  # of the GH issue
+  # Examples:
+  # to use fixed title "github issue": "github issue"
+  # to use GH issue title: "{issue.title}"
+  # to add prefix "[GitHub]" : "[GitHub] {issue.title}"
+  # to add user in the title: "[issue.user.login] {issue.title}"
+  # See GH issue definition : https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28
+  summary: "{issue.title}"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ settings:
   label_mapping:
     enhancement: Story
 
-  # (Optional) JIRA issue summary customization
-  # Allow to define the JIRA issue summary and eventually format it with the values
-  # of the GH issue
+  # (Optional) JIRA issue's summary customization
+  # Allow to define the JIRA issue's summary and eventually format it with the values
+  # of the GH issue variable.
+  # See GH issue definition : https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28
+  #
   # Examples:
   # to use fixed title "github issue": "github issue"
   # to use GH issue title: "{issue.title}"
   # to add prefix "[GitHub]" : "[GitHub] {issue.title}"
   # to add user in the title: "[issue.user.login] {issue.title}"
-  # See GH issue definition : https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28
   summary: "{issue.title}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ settings:
   # to use fixed title "github issue": "github issue"
   # to use GH issue title: "{issue.title}"
   # to add prefix "[GitHub]" : "[GitHub] {issue.title}"
-  # to add user in the title: "[issue.user.login] {issue.title}"
+  # to add user in the title (between square brackets): "[{issue.user.login}] {issue.title}"
   summary: "{issue.title}"
 ```
 

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -249,7 +249,7 @@ async def bot(request: Request, payload: dict = Body(...)):
     # to add prefix "GitHub" : "GitHub {issue.title}"
     # to add user in the title: "[issue.user.login] {issue.title}"
     summary_str = settings.get("summary", "")
-    if isinstance(summary_str, str) and summary_str != "":
+    if isinstance(summary_str, str) and summary_str:
         try:
             summary_str = settings["summary"].format(issue=issue)
             issue_dict["summary"] = summary_str

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -240,14 +240,15 @@ async def bot(request: Request, payload: dict = Body(...)):
         "issuetype": {"name": issue_type},
     }
 
-    # allow customization of JIRA issue summary field
-    # by using this field, use can format the JIRA summary with the values
-    # from the GH issue
-    # Examples:
-    # to use fixed title "github issue": "github issue"
-    # to use GH issue title: "{issue.title}"
-    # to add prefix "GitHub" : "GitHub {issue.title}"
-    # to add user in the title: "[issue.user.login] {issue.title}"
+    # Allow customization of JIRA issue's summary field
+    # By using this configuration field, use can format the summary with the values
+    # from the GH issue variable
+    #
+    # Examples of usage:
+    # - to use fixed title "github issue": "github issue"
+    # - to use GH issue title: "{issue.title}"
+    # - to add prefix "GitHub" : "GitHub {issue.title}"
+    # - to add user in the title: "[issue.user.login] {issue.title}"
     summary_str = settings.get("summary", "")
     if isinstance(summary_str, str) and summary_str:
         try:

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -239,6 +239,25 @@ async def bot(request: Request, payload: dict = Body(...)):
         "description": issue_description,
         "issuetype": {"name": issue_type},
     }
+
+    # allow customization of JIRA issue summary field
+    # by using this field, use can format the JIRA summary with the values
+    # from the GH issue
+    # Examples:
+    # to use fixed title "github issue": "github issue"
+    # to use GH issue title: "{issue.title}"
+    # to add prefix "GitHub" : "GitHub {issue.title}"
+    # to add user in the title: "[issue.user.login] {issue.title}"
+    summary_str = settings.get("summary", "")
+    if isinstance(summary_str, str) and summary_str != "":
+        try:
+            summary_str = settings["summary"].format(issue=issue)
+            issue_dict["summary"] = summary_str
+        except Exception:
+            msg = ".github/.jira_sync_config.yaml has invalid summary field. Check syntax."
+            logger.error(msg)
+            return {"msg": msg}
+
     if settings["epic_key"]:
         issue_dict["parent"] = {"key": settings["epic_key"]}
 

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -248,7 +248,7 @@ async def bot(request: Request, payload: dict = Body(...)):
     # - to use fixed title "github issue": "github issue"
     # - to use GH issue title: "{issue.title}"
     # - to add prefix "GitHub" : "GitHub {issue.title}"
-    # - to add user in the title: "[issue.user.login] {issue.title}"
+    # - to add user in the title: "[{issue.user.login}] {issue.title}"
     summary_str = settings.get("summary", "")
     if isinstance(summary_str, str) and summary_str:
         try:

--- a/github_jira_sync_app/settings.yaml
+++ b/github_jira_sync_app/settings.yaml
@@ -8,3 +8,4 @@ settings:
   jira_project_key:
   label_mapping:
   status_mapping:
+  summary: ""

--- a/github_jira_sync_app/settings.yaml
+++ b/github_jira_sync_app/settings.yaml
@@ -8,4 +8,4 @@ settings:
   jira_project_key:
   label_mapping:
   status_mapping:
-  summary: ""
+  summary:

--- a/tests/unit/dumm_env
+++ b/tests/unit/dumm_env
@@ -6,5 +6,5 @@ GITHUB_CLIENT_SECRET=rezindkm3dod04h12yt8oktm8if51wtsfgljk04k
 JIRA_INSTANCE="https://my-jira.atlassian.net"
 JIRA_USERNAME=maksim.beliaev@canonical.com
 JIRA_TOKEN=mv38swy07r6ius3v90cffyi4
-DEFAULT_BOT_CONFIG='{"settings": {"components": null, "labels": ["jira"], "add_gh_comment": false, "sync_description": true, "sync_comments": true, "epic_key": null, "jira_project_key": null, "label_mapping": null, "status_mapping": null}}'
+DEFAULT_BOT_CONFIG='{"settings": {"components": null, "labels": ["jira"], "add_gh_comment": false, "sync_description": true, "sync_comments": true, "epic_key": null, "jira_project_key": null, "label_mapping": null, "status_mapping": null, "summary": "{issue.user.login} {issue.title} my title"}}'
 BOT_NAME="syncronize-issues-to-jira[bot]"


### PR DESCRIPTION
For our project, we will need to add a prefix to the summary of JIRA issues that are created from GH issues.

For that purpose, we would like to propose to add a configuration field "summary" that will allow to customize
the JIRA issue summary.

This new feature will cover our need but also potentially allow other use cases where people need to do more advanced
customizations of the JIRA issue summary