### PR TITLE
Improve comment template

### DIFF
--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -42,7 +42,7 @@ PLEASE KEEP ALL THE CONVERSATION ON GITHUB
 """
 
 gh_comment_body_template = """
-Thank you for reporting us your feedback!
+Thank you for reporting your feedback to us!
 
 The internal ticket has been created: {jira_issue_link}.
 


### PR DESCRIPTION
The current message "Thank you for reporting us your feedback!" sounds a bit off in grammar sense (although I'm not a native speaker myself).

Changing this to "Thank you for reporting your feedback to us!" as this feels more natural.