### PR TITLE
Quote project key

### DIFF
--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -211,7 +211,8 @@ async def bot(request: Request, payload: dict = Body(...)):
     jira = JIRA(jira_instance_url, basic_auth=(jira_username, jira_token))
     jira_task_desc_match = f"This issue was created from GitHub Issue {issue.html_url}"
     existing_issues = jira.search_issues(
-        rf'project={settings["jira_project_key"]} AND description ~"\"{jira_task_desc_match}\""',
+        rf'project="{settings["jira_project_key"]}" AND '
+        + rf'description ~"\"{jira_task_desc_match}\""',
         json_result=False,
     )
     assert isinstance(existing_issues, list), "Jira did not return a list of existing issues"

--- a/tests/unit/url_responses/issue_labeled_correct.yaml
+++ b/tests/unit/url_responses/issue_labeled_correct.yaml
@@ -15,5 +15,4 @@ responses:
     content_type: text/plain
     method: GET
     status: 200
-    url: https://my-jira.atlassian.net/rest/api/2/search?jql=project%3DMTC+AND+description+~%22%5C%22This+issue+was+created+from+GitHub+Issue+https%3A%2F%2Fgithub.com%2Fbeliaev-maksim%2Ftest-ci%2Fissues%2F30%5C%22%22&startAt=0&validateQuery=True&fields=%2Aall&maxResults=50
-
+    url: https://my-jira.atlassian.net/rest/api/2/search?jql=project%3D%22MTC%22+AND+description+~%22%5C%22This+issue+was+created+from+GitHub+Issue+https%3A%2F%2Fgithub.com%2Fbeliaev-maksim%2Ftest-ci%2Fissues%2F30%5C%22%22&startAt=0&validateQuery=True&fields=%2Aall&maxResults=50

--- a/tests/unit/url_responses/issue_labeled_correct_for_existing_ticket.yaml
+++ b/tests/unit/url_responses/issue_labeled_correct_for_existing_ticket.yaml
@@ -27,5 +27,4 @@ responses:
     content_type: text/plain
     method: GET
     status: 200
-    url: https://my-jira.atlassian.net/rest/api/2/search?jql=project%3DMTC+AND+description+~%22%5C%22This+issue+was+created+from+GitHub+Issue+https%3A%2F%2Fgithub.com%2Fbeliaev-maksim%2Ftest-ci%2Fissues%2F30%5C%22%22&startAt=0&validateQuery=True&fields=%2Aall&maxResults=50
-
+    url: https://my-jira.atlassian.net/rest/api/2/search?jql=project%3D%22MTC%22+AND+description+~%22%5C%22This+issue+was+created+from+GitHub+Issue+https%3A%2F%2Fgithub.com%2Fbeliaev-maksim%2Ftest-ci%2Fissues%2F30%5C%22%22&startAt=0&validateQuery=True&fields=%2Aall&maxResults=50


### PR DESCRIPTION
For wider compatibility with project keys such as "SET", quote the key
in the SQL expression.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
