### PR TITLE
Add workflow to re-emit failed webhooks

### DIFF
--- a/.github/workflows/redeliver-webhooks.yaml
+++ b/.github/workflows/redeliver-webhooks.yaml
@@ -1,0 +1,36 @@
+name: Redeliver failed webhook deliveries
+
+# This workflow runs every hour or when manually triggered.
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+# This workflow will use the built in `GITHUB_TOKEN` to check out the repository contents. This grants `GITHUB_TOKEN` permission to do that.
+permissions:
+  contents: read
+
+#
+jobs:
+  redeliver-failed-deliveries:
+    name: Redeliver failed deliveries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo content
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+
+      # This step installs the octokit library. The script that this workflow will run uses the octokit library.
+      - name: Install dependencies
+        run: npm install octokit
+
+      - name: Run script
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          node .github/workflows/scripts/redeliver-failed-deliveries.js

--- a/.github/workflows/scripts/redeliver-failed-deliveries.js
+++ b/.github/workflows/scripts/redeliver-failed-deliveries.js
@@ -1,0 +1,126 @@
+// https://docs.github.com/en/webhooks/using-webhooks/automatically-redelivering-failed-deliveries-for-a-github-app-webhook
+const { App } = require("octokit");
+
+//
+async function checkAndRedeliverWebhooks() {
+  // Get the values of environment variables that were set by the GitHub Actions workflow.
+  const APP_ID = process.env.APP_ID;
+  const PRIVATE_KEY = process.env.PRIVATE_KEY;
+  
+  // Create an instance of the octokit `App` using the app ID and private key values that were set in the GitHub Actions workflow.
+  //
+  // This will be used to make API requests to the webhook-related endpoints.
+  const app = new App({
+    appId: APP_ID,
+    privateKey: PRIVATE_KEY,
+  });
+
+  try {
+    const lastWebhookRedeliveryTime = (Date.now() - (3 * 60 * 60 * 1000)).toString();
+
+    // Get the webhook deliveries that were delivered after `lastWebhookRedeliveryTime`.
+    const deliveries = await fetchWebhookDeliveriesSince({lastWebhookRedeliveryTime, app});
+
+    // Consolidate deliveries that have the same globally unique identifier (GUID). The GUID is constant across redeliveries of the same delivery.
+    let deliveriesByGuid = {};
+    for (const delivery of deliveries) {
+      deliveriesByGuid[delivery.guid]
+        ? deliveriesByGuid[delivery.guid].push(delivery)
+        : (deliveriesByGuid[delivery.guid] = [delivery]);
+    }
+
+    // For each GUID value, if no deliveries for that GUID have been successfully delivered within the time frame, get the delivery ID of one of the deliveries with that GUID.
+    //
+    // This will prevent duplicate redeliveries if a delivery has failed multiple times.
+    // This will also prevent redelivery of failed deliveries that have already been successfully redelivered.
+    let failedDeliveryIDs = [];
+    for (const guid in deliveriesByGuid) {
+      const deliveries = deliveriesByGuid[guid];
+      const anySucceeded = deliveries.some(
+        (delivery) => delivery.status === "OK"
+      );
+      if (!anySucceeded) {
+        failedDeliveryIDs.push(deliveries[0].id);
+      }
+    }
+
+    // Redeliver any failed deliveries.
+    for (const deliveryId of failedDeliveryIDs) {
+      await redeliverWebhook({deliveryId, app});
+    }
+
+    // Log the number of redeliveries.
+    console.log(
+      `Redelivered ${
+        failedDeliveryIDs.length
+      } failed webhook deliveries out of ${
+        deliveries.length
+      } total deliveries since ${Date(lastWebhookRedeliveryTime)}.`
+    );
+  } catch (error) {
+    // If there was an error, log the error so that it appears in the workflow run log, then throw the error so that the workflow run registers as a failure.
+    if (error.response) {
+      console.error(
+        `Failed to check and redeliver webhooks: ${error.response.data.message}`
+      );
+    }
+    console.error(error);
+    throw(error);
+  }
+}
+
+// This function will fetch all of the webhook deliveries that were delivered since `lastWebhookRedeliveryTime`.
+// It uses the `octokit.paginate.iterator()` method to iterate through paginated results. For more information, see "[AUTOTITLE](/rest/guides/scripting-with-the-rest-api-and-javascript#making-paginated-requests)."
+//
+// If a page of results includes deliveries that occurred before `lastWebhookRedeliveryTime`,
+// it will store only the deliveries that occurred after `lastWebhookRedeliveryTime` and then stop.
+// Otherwise, it will store all of the deliveries from the page and request the next page.
+async function fetchWebhookDeliveriesSince({lastWebhookRedeliveryTime, app}) {
+  const iterator = app.octokit.paginate.iterator(
+    "GET /app/hook/deliveries",
+    {
+      per_page: 100,
+      headers: {
+        "x-github-api-version": "2022-11-28",
+      },
+    }
+  );
+
+  const deliveries = [];
+
+  for await (const { data } of iterator) {
+    const oldestDeliveryTimestamp = new Date(
+      data[data.length - 1].delivered_at
+    ).getTime();
+
+    if (oldestDeliveryTimestamp < lastWebhookRedeliveryTime) {
+      for (const delivery of data) {
+        if (
+          new Date(delivery.delivered_at).getTime() > lastWebhookRedeliveryTime
+        ) {
+          deliveries.push(delivery);
+        } else {
+          break;
+        }
+      }
+      break;
+    } else {
+      deliveries.push(...data);
+    }
+  }
+
+  return deliveries;
+}
+
+// This function will redeliver a failed webhook delivery.
+async function redeliverWebhook({deliveryId, app}) {
+  await app.octokit.request("POST /app/hook/deliveries/{delivery_id}/attempts", {
+    delivery_id: deliveryId,
+  });
+}
+
+// This will execute the `checkAndRedeliverWebhooks` function.
+(async () => {
+  await checkAndRedeliverWebhooks();
+})();
+


### PR DESCRIPTION
Following https://docs.github.com/en/webhooks/using-webhooks/automatically-redelivering-failed-deliveries-for-a-github-app-webhook

Added a simplified script that will trigger every hour and redeliver all the webhooks failed in the last 3 hours. That is required to have some overlap in case of a series of failed deliveries
Subject to increase overlap time