### PR TITLE
bump dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ description = "FastAPI server to serve GitHub bot that synchronizes issues from 
 dynamic = ["version"]
 
 dependencies = [
-    "fastapi==0.109.1",
-    "pyyaml==6.0.0",
+    "fastapi==0.115.6",
+    "pyyaml==6.0.2",
     "pygithub==1.59.0",
     "uvicorn[standard]==0.22.0",
     "load_dotenv==0.1.0",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -22,7 +22,7 @@ def _get_json(file_name):
 
 
 def test_hash_validation():
-    data_hash = "sha256=38be3341f7b03bb234534be165ce4444d52bd95e798f547cabb1622db3628caa"
+    data_hash = "sha256=7127498186b8a9b282a54b72a954151d98681416693e07ea46e3a3eb960ddb42"
     response = client.post(
         "/",
         json=_get_json("comment_created_by_bot.json"),


### PR DESCRIPTION
the issue is that HTTPX 0.28 alters the default separators. Thus, change of a hash in the test should be safe

https://github.com/encode/httpx/pull/3367