### PR TITLE
feat: Assign pulse to Jira ticket on GH close

### DIFF
--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -23,6 +23,7 @@ from mistletoe.contrib.jira_renderer import JIRARenderer  # type: ignore[import]
 from yaml.scanner import ScannerError
 
 from .instrumentation.metrics import setup_metrics
+from .pulse_utils import process_pulse_assignment
 
 jira_text_renderer = JIRARenderer()
 
@@ -193,6 +194,36 @@ def _generate_summary(settings: dict, issue: Issue):
             logger.error(msg)
 
     return issue.title
+
+
+def _handle_pulse_assignment(jira: JIRA, jira_issue, gh_issue_payload: dict, settings: dict):
+    """Handle pulse assignment for a closed issue.
+
+    Args:
+        jira: Authenticated Jira client
+        jira_issue: Jira issue object
+        gh_issue_payload: GitHub issue payload from webhook
+        settings: Configuration settings
+
+    Returns:
+        Optional[str]: Success message if pulse was assigned, None otherwise
+    """
+    pulse_config = settings.get("pulse_assignment", {})
+    if not pulse_config.get("enabled", False):
+        return None
+
+    # Get the closed_at timestamp from the GitHub issue
+    closed_at = gh_issue_payload.get("closed_at")
+    if not closed_at:
+        logger.warning("GitHub issue has no closed_at timestamp, cannot assign pulse")
+        return None
+
+    # Extract just the date part (YYYY-MM-DD) from the ISO 8601 timestamp
+    closed_date = closed_at.split("T")[0]
+
+    return process_pulse_assignment(
+        jira, jira_issue, closed_date, pulse_config, settings["jira_project_key"]
+    )
 
 
 @app.post("/")
@@ -380,10 +411,18 @@ async def bot(request: Request, payload: dict = Body(...)):
         if payload["action"] == "closed":
             if payload["issue"]["state_reason"] == "not_planned":
                 jira.transition_issue(jira_issue, not_planned_status)
-                return {"msg": "Closed existing Jira Issue as not planned"}
+                pulse_msg = _handle_pulse_assignment(jira, jira_issue, payload["issue"], settings)
+                msg = "Closed existing Jira Issue as not planned"
+                if pulse_msg:
+                    msg += f". {pulse_msg}"
+                return {"msg": msg}
             else:
                 jira.transition_issue(jira_issue, closed_status)
-                return {"msg": "Closed existing Jira Issue"}
+                pulse_msg = _handle_pulse_assignment(jira, jira_issue, payload["issue"], settings)
+                msg = "Closed existing Jira Issue"
+                if pulse_msg:
+                    msg += f". {pulse_msg}"
+                return {"msg": msg}
         elif payload["action"] == "reopened":
             jira.transition_issue(jira_issue, opened_status)
             return {"msg": "Reopened existing Jira Issue"}

--- a/github_jira_sync_app/pulse_utils.py
+++ b/github_jira_sync_app/pulse_utils.py
@@ -1,0 +1,290 @@
+"""Pulse (Sprint) assignment utilities for Jira issues."""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from jira import JIRA
+
+logger = logging.getLogger("sync-bot-server")
+
+
+def calculate_pulse(closed_date: str, reference_start_date: str = "2026-01-05") -> tuple[int, int]:
+    """Calculate pulse number based on closed date.
+
+    Pulses follow a strict 2-week (14-day) cadence starting from a reference date.
+    There are 26 pulses per year, and the count resets every year.
+
+    Args:
+        closed_date: Date when issue was closed (ISO format: YYYY-MM-DD)
+        reference_start_date: Start date of Pulse 1 for the reference year (default: Jan 5, 2026)
+
+    Returns:
+        tuple: (year, pulse_number) where pulse_number is 1-26
+
+    Examples:
+        >>> calculate_pulse("2026-01-05", "2026-01-05")
+        (2026, 1)
+        >>> calculate_pulse("2026-01-19", "2026-01-05")
+        (2026, 2)
+        >>> calculate_pulse("2026-02-11", "2026-01-05")
+        (2026, 3)
+    """
+    # Parse dates
+    closed = datetime.strptime(closed_date, "%Y-%m-%d")
+    reference = datetime.strptime(reference_start_date, "%Y-%m-%d")
+
+    # Calculate days since reference
+    days_diff = (closed - reference).days
+
+    # Each pulse is 14 days
+    pulse_offset = days_diff // 14
+
+    # Calculate pulse number (1-indexed, wraps every 26 pulses)
+    pulse_number = (pulse_offset % 26) + 1
+
+    # Calculate year (reference year + full cycles of 26 pulses)
+    year = reference.year + (pulse_offset // 26)
+
+    return (year, pulse_number)
+
+
+def format_sprint_name(
+    year: int, pulse_number: int, pattern: str = "Pulse {year}#{number} - Web & Design"
+) -> str:
+    """Format sprint name according to the configured pattern.
+
+    Args:
+        year: Year of the pulse
+        pulse_number: Pulse number (1-26)
+        pattern: Name pattern with {year} and {number} placeholders
+
+    Returns:
+        str: Formatted sprint name
+
+    Examples:
+        >>> format_sprint_name(2026, 3)
+        'Pulse 2026#03 - Web & Design'
+        >>> format_sprint_name(2026, 24)
+        'Pulse 2026#24 - Web & Design'
+    """
+    # Format pulse number with leading zero (01-26)
+    return pattern.format(year=year, number=f"{pulse_number:02d}")
+
+
+def find_sprint_start_date(jira: JIRA, board_id: int, sprint_name: str) -> Optional[str]:
+    """Find a sprint start date by its name on a specific board.
+
+    Returns the date portion (YYYY-MM-DD) when startDate is available.
+    """
+    try:
+        start_at = 0
+        max_results = 50
+
+        while True:
+            sprints = jira._get_json(
+                f"agile/1.0/board/{board_id}/sprint",
+                params={"startAt": start_at, "maxResults": max_results},
+            )
+
+            for sprint in sprints.get("values", []):
+                if sprint.get("name") == sprint_name:
+                    start_date = sprint.get("startDate")
+                    if start_date:
+                        return start_date.split("T")[0]
+                    logger.warning(
+                        f"Sprint '{sprint_name}' has no startDate; using configured fallback"
+                    )
+                    return None
+
+            if sprints.get("isLast", True):
+                break
+
+            start_at += max_results
+
+        logger.warning(f"Sprint '{sprint_name}' not found on board {board_id}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error finding sprint '{sprint_name}' on board {board_id}: {e}")
+        return None
+
+
+def find_sprint_by_name(jira: JIRA, board_id: int, sprint_name: str) -> Optional[int]:
+    """Find a sprint ID by its name on a specific board.
+
+    Args:
+        jira: Authenticated Jira client
+        board_id: ID of the Jira board to search
+        sprint_name: Name of the sprint to find
+
+    Returns:
+        Optional[int]: Sprint ID if found, None otherwise
+    """
+    try:
+        # Get all sprints from the board
+        # The API may paginate results, so we need to handle that
+        start_at = 0
+        max_results = 50
+
+        while True:
+            sprints = jira._get_json(
+                f"agile/1.0/board/{board_id}/sprint",
+                params={"startAt": start_at, "maxResults": max_results},
+            )
+
+            for sprint in sprints.get("values", []):
+                if sprint.get("name") == sprint_name:
+                    return sprint.get("id")
+
+            # Check if there are more results
+            if sprints.get("isLast", True):
+                break
+
+            start_at += max_results
+
+        logger.warning(f"Sprint '{sprint_name}' not found on board {board_id}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error finding sprint '{sprint_name}' on board {board_id}: {e}")
+        return None
+
+
+def assign_sprint_to_issue(
+    jira: JIRA, issue_key: str, sprint_id: int, sprint_field_id: str
+) -> bool:
+    """Assign a sprint to a Jira issue.
+
+    Args:
+        jira: Authenticated Jira client
+        issue_key: Key of the issue to update (e.g., "WD-12345")
+        sprint_id: ID of the sprint to assign
+        sprint_field_id: Custom field ID for sprint (e.g., "customfield_10020")
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        issue = jira.issue(issue_key)
+        issue.update(fields={sprint_field_id: sprint_id})
+        logger.info(f"Assigned sprint {sprint_id} to issue {issue_key}")
+        return True
+    except Exception as e:
+        logger.error(f"Error assigning sprint {sprint_id} to issue {issue_key}: {e}")
+        return False
+
+
+def should_assign_pulse(jira_issue, pulse_config: dict, jira_project_key: str) -> tuple[bool, str]:
+    """Check if pulse should be assigned to the issue based on pre-conditions.
+
+    Args:
+        jira_issue: Jira issue object
+        pulse_config: Pulse assignment configuration from settings
+        jira_project_key: Expected project key
+
+    Returns:
+        tuple: (should_assign: bool, reason: str)
+    """
+    # Check if feature is enabled
+    if not pulse_config.get("enabled", False):
+        return False, "Pulse assignment is not enabled"
+
+    # Check if project matches
+    if not pulse_config.get("project_key"):
+        return False, "Pulse assignment project_key not configured"
+
+    if jira_issue.fields.project.key != pulse_config["project_key"]:
+        return (
+            False,
+            f"Issue project {jira_issue.fields.project.key} does not match "
+            f"pulse_assignment.project_key {pulse_config['project_key']}",
+        )
+
+    # Check if issue already has a sprint assigned
+    sprint_field_id = pulse_config.get("sprint_field_id", "customfield_10020")
+    current_sprint = getattr(jira_issue.fields, sprint_field_id, None)
+    if current_sprint is not None:
+        return False, f"Issue already has sprint assigned: {current_sprint}"
+
+    return True, "All conditions met"
+
+
+def process_pulse_assignment(
+    jira: JIRA,
+    jira_issue,
+    closed_date: str,
+    pulse_config: dict,
+    jira_project_key: str,
+) -> Optional[str]:
+    """Process pulse assignment for a closed issue.
+
+    This is the main orchestration function that handles the complete pulse assignment workflow:
+    1. Validates pre-conditions
+    2. Calculates the appropriate pulse
+    3. Looks up the sprint in Jira
+    4. Assigns the sprint to the issue
+
+    Args:
+        jira: Authenticated Jira client
+        jira_issue: Jira issue object to assign pulse to
+        closed_date: Date when the GitHub issue was closed (ISO format)
+        pulse_config: Pulse assignment configuration from settings
+        jira_project_key: Jira project key
+
+    Returns:
+        Optional[str]: Success message if pulse was assigned, None otherwise
+    """
+    # Check pre-conditions
+    should_assign, reason = should_assign_pulse(jira_issue, pulse_config, jira_project_key)
+    if not should_assign:
+        logger.info(f"Skipping pulse assignment for {jira_issue.key}: {reason}")
+        return None
+
+    # Get configuration
+    board_id = pulse_config.get("board_id")
+    sprint_field_id = pulse_config.get("sprint_field_id", "customfield_10020")
+    sprint_name_pattern = pulse_config.get(
+        "sprint_name_pattern", "Pulse {year}#{number} - Web & Design"
+    )
+    if not board_id:
+        logger.error("Pulse assignment board_id not configured")
+        return None
+
+    year = int(closed_date.split("-")[0])
+    pulse_one_name = format_sprint_name(year, 1, sprint_name_pattern)
+    reference_date = find_sprint_start_date(jira, board_id, pulse_one_name)
+    if not reference_date:
+        logger.warning(
+            "Pulse 01 startDate is unavailable. Skipping pulse assignment until it exists."
+        )
+        return None
+
+    try:
+        # Calculate pulse
+        year, pulse_number = calculate_pulse(closed_date, reference_date)
+        sprint_name = format_sprint_name(year, pulse_number, sprint_name_pattern)
+
+        logger.info(
+            f"Calculated pulse for {jira_issue.key}: {sprint_name} " f"(closed on {closed_date})"
+        )
+
+        # Find sprint
+        sprint_id = find_sprint_by_name(jira, board_id, sprint_name)
+        if sprint_id is None:
+            logger.warning(
+                f"Sprint '{sprint_name}' not found on board {board_id}. "
+                f"Skipping pulse assignment for {jira_issue.key}"
+            )
+            return None
+
+        # Assign sprint
+        success = assign_sprint_to_issue(jira, jira_issue.key, sprint_id, sprint_field_id)
+        if success:
+            return f"Assigned pulse {sprint_name} to {jira_issue.key}"
+        else:
+            return None
+
+    except Exception as e:
+        logger.error(f"Error processing pulse assignment for {jira_issue.key}: {e}")
+        return None

--- a/github_jira_sync_app/settings.yaml
+++ b/github_jira_sync_app/settings.yaml
@@ -10,3 +10,9 @@ settings:
   label_mapping:
   status_mapping:
   summary:
+  pulse_assignment:
+    enabled: false
+    project_key:
+    board_id:
+    sprint_field_id: "customfield_10020"
+    sprint_name_pattern: "Pulse {year}#{number} - Web & Design"

--- a/tests/unit/payloads/issue_closed_with_pulse.json
+++ b/tests/unit/payloads/issue_closed_with_pulse.json
@@ -1,0 +1,95 @@
+{
+  "action": "closed",
+  "issue": {
+    "url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30",
+    "repository_url": "https://api.github.com/repos/beliaev-maksim/test-ci",
+    "labels_url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30/labels{/name}",
+    "comments_url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30/comments",
+    "events_url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30/events",
+    "html_url": "https://github.com/beliaev-maksim/test-ci/issues/30",
+    "id": 2466054162,
+    "node_id": "I_kwDOI7Rtfs6S_QAS",
+    "number": 30,
+    "title": "new test",
+    "user": {
+      "login": "beliaev-maksim",
+      "id": 51964909,
+      "node_id": "MDQ6VXNlcjUxOTY0OTA5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/51964909?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/beliaev-maksim",
+      "html_url": "https://github.com/beliaev-maksim",
+      "type": "User",
+      "site_admin": false
+    },
+    "labels": [
+      {
+        "id": 5157325446,
+        "node_id": "LA_kwDOI-HsRM8AAAABM2aKhg",
+        "url": "https://api.github.com/repos/beliaev-maksim/test-ci/labels/bug",
+        "name": "bug",
+        "color": "d73a4a",
+        "default": true,
+        "description": "Something isn't working"
+      }
+    ],
+    "state": "closed",
+    "locked": false,
+    "assignee": null,
+    "assignees": [],
+    "milestone": null,
+    "comments": 1,
+    "created_at": "2026-02-08T10:00:00Z",
+    "updated_at": "2026-02-11T15:30:00Z",
+    "closed_at": "2026-02-11T15:30:00Z",
+    "author_association": "OWNER",
+    "active_lock_reason": null,
+    "body": null,
+    "reactions": {
+      "url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "timeline_url": "https://api.github.com/repos/beliaev-maksim/test-ci/issues/30/timeline",
+    "performed_via_github_app": null,
+    "state_reason": "completed"
+  },
+  "repository": {
+    "id": 599027070,
+    "node_id": "R_kgDOI7Rtfg",
+    "name": "test-ci",
+    "full_name": "beliaev-maksim/test-ci",
+    "private": false,
+    "owner": {
+      "login": "beliaev-maksim",
+      "id": 51964909,
+      "node_id": "MDQ6VXNlcjUxOTY0OTA5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/51964909?v=4",
+      "url": "https://api.github.com/users/beliaev-maksim",
+      "type": "User",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/beliaev-maksim/test-ci",
+    "description": "Test repo",
+    "fork": false,
+    "created_at": "2023-02-04T11:57:49Z",
+    "updated_at": "2023-02-04T12:30:23Z",
+    "pushed_at": "2024-08-14T14:40:45Z"
+  },
+  "sender": {
+    "login": "beliaev-maksim",
+    "id": 51964909,
+    "node_id": "MDQ6VXNlcjUxOTY0OTA5",
+    "avatar_url": "https://avatars.githubusercontent.com/u/51964909?v=4",
+    "url": "https://api.github.com/users/beliaev-maksim",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/tests/unit/test_pulse_utils.py
+++ b/tests/unit/test_pulse_utils.py
@@ -1,0 +1,156 @@
+"""Unit tests for pulse_utils module."""
+
+from unittest.mock import Mock
+
+from github_jira_sync_app.pulse_utils import calculate_pulse
+from github_jira_sync_app.pulse_utils import format_sprint_name
+from github_jira_sync_app.pulse_utils import process_pulse_assignment
+from github_jira_sync_app.pulse_utils import should_assign_pulse
+
+
+class TestCalculatePulse:
+    """Test pulse calculation logic."""
+
+    def test_pulse_3_mid_period(self):
+        """Test that dates in the middle of a pulse round down correctly."""
+        # Feb 11 is 37 days after Jan 5, which is 2 full periods + 9 days
+        # Should be Pulse 3 (periods 0, 1, 2 = pulses 1, 2, 3)
+        year, pulse = calculate_pulse("2026-02-11", "2026-01-05")
+        assert year == 2026
+        assert pulse == 3
+
+
+class TestFormatSprintName:
+    """Test sprint name formatting."""
+
+    def test_default_pattern_single_digit(self):
+        """Test default pattern with single digit pulse number."""
+        name = format_sprint_name(2026, 1)
+        assert name == "Pulse 2026#01 - Web & Design"
+
+
+class TestShouldAssignPulse:
+    """Test pre-condition validation logic."""
+
+    def test_feature_disabled(self):
+        """Test that disabled feature returns False."""
+        pulse_config = {"enabled": False}
+        mock_issue = Mock()
+
+        should_assign, reason = should_assign_pulse(mock_issue, pulse_config, "WD")
+
+        assert should_assign is False
+        assert "not enabled" in reason
+
+    def test_project_mismatch(self):
+        """Test that project mismatch returns False."""
+        pulse_config = {"enabled": True, "project_key": "WD"}
+        mock_issue = Mock()
+        mock_issue.fields.project.key = "OTHER"
+
+        should_assign, reason = should_assign_pulse(mock_issue, pulse_config, "WD")
+
+        assert should_assign is False
+        assert "does not match" in reason
+
+    def test_sprint_already_assigned(self):
+        """Test that existing sprint returns False."""
+        pulse_config = {
+            "enabled": True,
+            "project_key": "WD",
+            "sprint_field_id": "customfield_10020",
+        }
+        mock_issue = Mock()
+        mock_issue.fields.project.key = "WD"
+        setattr(mock_issue.fields, "customfield_10020", 123)  # Sprint already assigned
+
+        should_assign, reason = should_assign_pulse(mock_issue, pulse_config, "WD")
+
+        assert should_assign is False
+        assert "already has sprint" in reason
+
+
+class TestProcessPulseAssignment:
+    """Test the main pulse assignment workflow."""
+
+    def test_process_pulse_assignment_success(self):
+        """Test successful pulse assignment end-to-end."""
+        mock_jira = Mock()
+        mock_issue = Mock()
+        mock_issue.key = "WD-12345"
+        mock_issue.fields.project.key = "WD"
+        setattr(mock_issue.fields, "customfield_10020", None)
+
+        # Mock sprint lookup + auto start date
+        mock_jira._get_json.return_value = {
+            "values": [
+                {
+                    "id": 101,
+                    "name": "Pulse 2026#01 - Web & Design",
+                    "startDate": "2026-01-05T09:00:00.000+0000",
+                },
+                {"id": 123, "name": "Pulse 2026#03 - Web & Design"},
+            ],
+            "isLast": True,
+        }
+
+        # Mock issue update
+        mock_jira.issue.return_value = mock_issue
+
+        pulse_config = {
+            "enabled": True,
+            "project_key": "WD",
+            "board_id": 932,
+            "sprint_field_id": "customfield_10020",
+            "sprint_name_pattern": "Pulse {year}#{number} - Web & Design",
+        }
+
+        result = process_pulse_assignment(mock_jira, mock_issue, "2026-02-11", pulse_config, "WD")
+
+        assert result is not None
+        assert "Pulse 2026#03" in result
+        assert "WD-12345" in result
+        mock_issue.update.assert_called_once()
+
+    def test_process_pulse_assignment_sprint_not_found(self):
+        """Test that sprint not found returns None."""
+        mock_jira = Mock()
+        mock_issue = Mock()
+        mock_issue.key = "WD-12345"
+        mock_issue.fields.project.key = "WD"
+        setattr(mock_issue.fields, "customfield_10020", None)
+
+        # Sprint not found
+        mock_jira._get_json.return_value = {
+            "values": [],
+            "isLast": True,
+        }
+
+        pulse_config = {
+            "enabled": True,
+            "project_key": "WD",
+            "board_id": 932,
+            "sprint_field_id": "customfield_10020",
+        }
+
+        result = process_pulse_assignment(mock_jira, mock_issue, "2026-02-11", pulse_config, "WD")
+
+        assert result is None
+
+    def test_process_pulse_assignment_missing_board_id(self):
+        """Test that missing board_id returns None."""
+        mock_jira = Mock()
+        mock_issue = Mock()
+        mock_issue.key = "WD-12345"
+        mock_issue.fields.project.key = "WD"
+        setattr(mock_issue.fields, "customfield_10020", None)
+
+        pulse_config = {
+            "enabled": True,
+            "project_key": "WD",
+            # board_id missing
+        }
+
+        result = process_pulse_assignment(mock_jira, mock_issue, "2026-02-11", pulse_config, "WD")
+
+        assert result is None

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -278,3 +278,68 @@ def test_issue_created_and_synced_label(signature_mock):
             "Purposefully ignored as caused by this bot."
         )
     }
+
+
+@responses.activate(assert_all_requests_are_fired=True)
+def test_issue_closed_with_pulse_assignment(signature_mock):
+    """Test pulse assignment when an issue is closed.
+
+    Tests the following scenario:
+        1. Authenticate in GitHub
+        2. Get issue from GitHub
+        3. Get content of .jira_sync_config.yaml from GitHub repo (with pulse_assignment enabled)
+        4. Authenticate in Jira
+        5. Find existing Jira issue via JQL
+        6. Transition issue to closed
+        7. Calculate pulse based on closed_at date (Feb 11, 2026 -> Pulse 2026#03)
+        8. Query Jira for sprint list
+        9. Update issue with sprint field
+    """
+    responses._add_from_file(
+        UNITTESTS_DIR / "url_responses" / "jira_jql_existing_issues_for_pulse.yaml"
+    )
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "github_auth.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "github_settings_with_pulse.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_auth_responses_minimal.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_transition_issue.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_sprint_list.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_update_sprint.yaml")
+
+    response = client.post(
+        "/",
+        json=_get_json("issue_closed_with_pulse.json"),
+    )
+
+    assert response.status_code == 200
+    assert "Closed existing Jira Issue" in response.json()["msg"]
+    assert "Pulse 2026#03" in response.json()["msg"]
+
+
+@responses.activate(assert_all_requests_are_fired=False)
+def test_issue_closed_pulse_assignment_disabled(signature_mock):
+    """Test that pulse assignment is skipped when disabled.
+
+    Tests the following scenario:
+        1. Authenticate in GitHub
+        2. Get issue from GitHub
+        3. Get content of .jira_sync_config.yaml from GitHub repo (without pulse_assignment)
+        4. Authenticate in Jira
+        5. Find existing Jira issue via JQL
+        6. Transition issue to closed
+        7. No pulse assignment (feature disabled)
+    """
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_jql_existing_issues.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "github_auth.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "github_settings_with_labels.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_auth_responses.yaml")
+    responses._add_from_file(UNITTESTS_DIR / "url_responses" / "jira_transition_issue.yaml")
+
+    response = client.post(
+        "/",
+        json=_get_json("issue_closed_with_pulse.json"),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Closed existing Jira Issue"}
+    # Should not contain pulse information
+    assert "Pulse" not in response.json()["msg"]

--- a/tests/unit/url_responses/github_settings_with_pulse.yaml
+++ b/tests/unit/url_responses/github_settings_with_pulse.yaml
@@ -1,0 +1,8 @@
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '{"name":".jira_sync_config.yaml","path":".github/.jira_sync_config.yaml","sha":"68e8f1b3f89d4f9e7ea08a41c75c2ce07061e04e","size":267,"url":"https://api.github.com/repos/beliaev-maksim/test-ci/contents/.github/.jira_sync_config.yaml?ref=main","html_url":"https://github.com/beliaev-maksim/test-ci/blob/main/.github/.jira_sync_config.yaml","git_url":"https://api.github.com/repos/beliaev-maksim/test-ci/git/blobs/68e8f1b3f89d4f9e7ea08a41c75c2ce07061e04e","download_url":"https://raw.githubusercontent.com/beliaev-maksim/test-ci/main/.github/.jira_sync_config.yaml","type":"file","content":"c2V0dGluZ3M6CiAgbGFiZWxzOgogICAgLSBidWcKICBqaXJhX3Byb2plY3Rfa2V5OiBXRAogIHN0YXR1c19tYXBwaW5nOgogICAgb3BlbmVkOiAiVG8gRG8iCiAgICBjbG9zZWQ6ICJEb25lIgogICAgbm90X3BsYW5uZWQ6ICJEb25lIgogIHB1bHNlX2Fzc2lnbm1lbnQ6CiAgICBlbmFibGVkOiB0cnVlCiAgICBwcm9qZWN0X2tleTogIldEIgogICAgYm9hcmRfaWQ6IDkzMgogICAgc3ByaW50X2ZpZWxkX2lkOiAiY3VzdG9tZmllbGRfMTAwMjAiCiAgICBzcHJpbnRfbmFtZV9wYXR0ZXJuOiAiUHVsc2Uge3llYXJ9I3tudW1iZXJ9IC0gV2ViICYgRGVzaWduIgo=","encoding":"base64"}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://api.github.com:443/repos/beliaev-maksim/test-ci/contents/.github/.jira_sync_config.yaml

--- a/tests/unit/url_responses/jira_auth_responses_minimal.yaml
+++ b/tests/unit/url_responses/jira_auth_responses_minimal.yaml
@@ -1,0 +1,17 @@
+# Minimal Jira auth responses for pulse tests
+# Only includes serverInfo and field, no components mock (not needed when components: null)
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '{"baseUrl":"https://my-jira.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100229,"buildDate":"2023-07-04T14:01:07.000+0100","serverTime":"2023-07-05T12:56:24.472+0100","scmInfo":"634ba050f968f89f209dd80db6760d2dfbef51e5","serverTitle":"Jira","defaultLocale":{"locale":"en_US"}}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/serverInfo
+  - response:
+      auto_calculate_content_length: false
+      body: "[{}]"
+      content_type: text/plain; charset=utf-8
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/field

--- a/tests/unit/url_responses/jira_jql_existing_issues_for_pulse.yaml
+++ b/tests/unit/url_responses/jira_jql_existing_issues_for_pulse.yaml
@@ -1,0 +1,8 @@
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '{"expand":"names,schema","startAt":0,"maxResults":50,"total":1,"issues":[{"expand":"operations,versionedRepresentations,editmeta,changelog,renderedFields","id":"10002","self":"https://my-jira.atlassian.net/rest/api/2/issue/10002","key":"MTC-314","fields":{"summary":"new test","description":"This issue was created from GitHub Issue https://github.com/beliaev-maksim/test-ci/issues/30","issuetype":{"name":"Bug"},"project":{"id":"10000","key":"WD","name":"Web & Design"},"parent":{"id":"10001","key":"WD-31040","self":"https://my-jira.atlassian.net/rest/api/2/issue/10001","fields":{"summary":"Parent Epic"}},"status":{"name":"To Do","id":"10011"},"customfield_10020":null}}]}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/search/jql?jql=project%3D%22WD%22+AND+description+~%22%5C%22This+issue+was+created+from+GitHub+Issue+https%3A%2F%2Fgithub.com%2Fbeliaev-maksim%2Ftest-ci%2Fissues%2F30%5C%22%22&fields=%2Aall&maxResults=50

--- a/tests/unit/url_responses/jira_sprint_list.yaml
+++ b/tests/unit/url_responses/jira_sprint_list.yaml
@@ -1,0 +1,8 @@
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '{"values":[{"id":123,"name":"Pulse 2026#01 - Web & Design","state":"active","startDate":"2026-01-01T00:00:00.000Z"},{"id":124,"name":"Pulse 2026#02 - Web & Design","state":"closed","startDate":"2026-01-15T00:00:00.000Z"},{"id":125,"name":"Pulse 2026#03 - Web & Design","state":"active","startDate":"2026-01-29T00:00:00.000Z"}],"isLast":true}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/agile/1.0/board/932/sprint?startAt=0&maxResults=50

--- a/tests/unit/url_responses/jira_update_sprint.yaml
+++ b/tests/unit/url_responses/jira_update_sprint.yaml
@@ -1,0 +1,22 @@
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '{"id":"10002","self":"https://my-jira.atlassian.net/rest/api/2/issue/10002","key":"MTC-314","fields":{"summary":"new test","description":"Test issue","project":{"key":"WD"}}}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/issue/MTC-314
+  - response:
+      auto_calculate_content_length: false
+      body: '{"id":"10002","self":"https://my-jira.atlassian.net/rest/api/2/issue/10002","key":"MTC-314","fields":{"summary":"new test","description":"Test issue","project":{"key":"WD"}}}'
+      content_type: text/plain
+      method: GET
+      status: 200
+      url: https://my-jira.atlassian.net/rest/api/2/issue/10002
+  - response:
+      auto_calculate_content_length: false
+      body: ""
+      content_type: text/plain
+      method: PUT
+      status: 204
+      url: https://my-jira.atlassian.net/rest/api/2/issue/10002


### PR DESCRIPTION
## Rationale
When a github issue is closed on one of our repos which uses this bot the corresponding jira ticket is also closed _but_ we have to manually assign the pulse to the jira ticket. This can get quite tedious so this PR introduces functionality to automatically assign the corresponding pulse to the jira ticket on close.  

## Done

- Implemented automatic pulse (sprint) assignment when github issues are closed
- Implemented auto-detect Pulse 01 start date from jira sprint metadata
- Added tests for the above functionality 

## Assumptions and limitations
This solution assumes that the sprint field as used in our Jira instance does indeed include a `startDate` in the response body as stated in the [Jira docs](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-get). I ideally would have liked to confirm this directly but lack the needed permissions. 

If Pulse 01 for the current year doesn't exist yet in Jira or doesn't have a `startDate` set, pulse assignment will be skipped until it's available. This prevents incorrect assignments but means the feature won't work until the first pulse of the year is created in Jira.

Currently, this will only work for the Web & Design project since the pulse naming convention is not standardized across all Canonical projects.  

## Closes
https://warthogs.atlassian.net/browse/WD-31783
