### PR TITLE
Add support for configuring the Jira Team field

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ settings:
   components:
     - IoT
     - DACH TT
+
+  # (Optional) Jira team to assign to the created issue
+  # Use the team's UUID, which can be found by fetching an existing Jira issue
+  # that already has the team set and inspecting the `customfield_10001` field:
+  #   curl -u user@example.com:TOKEN https://your-instance.atlassian.net/rest/api/2/issue/PROJ-123
+  team: "bf14f26e-a188-4f4a-8ad4-e2686fb2ca90"
       
   # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
   # If not specified, all issues will be synchronized

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -358,6 +358,9 @@ async def bot(request: Request, payload: dict = Body(...)):
             if component in allowed_components
         ]
 
+    if settings["team"]:
+        issue_dict["customfield_10001"] = {"id": settings["team"]}
+
     opened_status = settings["status_mapping"]["opened"]
     closed_status = settings["status_mapping"]["closed"]
     not_planned_status = settings["status_mapping"].get("not_planned", closed_status)

--- a/github_jira_sync_app/settings.yaml
+++ b/github_jira_sync_app/settings.yaml
@@ -1,5 +1,6 @@
 settings:
   components:
+  team:
   labels:
   add_gh_comment: false
   add_gh_synced_label: false

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,6 +18,7 @@ def _default_settings(**overrides):
     settings = {
         "settings": {
             "components": None,
+            "team": None,
             "labels": ["bug"],
             "add_gh_comment": False,
             "add_gh_synced_label": False,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -222,6 +222,30 @@ class TestCreateNewJiraIssue:
         fields = call_kwargs[1]["fields"]
         assert fields["components"] == [{"name": "Frontend"}]
 
+    def test_create_with_team(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(team="bf14f26e-a188-4f4a-8ad4-e2686fb2ca90")
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        response = client.post("/", json=_get_json("issue_labeled_correct.json"))
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["customfield_10001"] == {"id": "bf14f26e-a188-4f4a-8ad4-e2686fb2ca90"}
+
+    def test_create_without_team(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(team=None)
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        response = client.post("/", json=_get_json("issue_labeled_correct.json"))
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert "customfield_10001" not in fields
+
     def test_create_with_label_mapping(self, signature_mock, mock_github, mock_jira):
         from tests.unit.conftest import _default_settings
 


### PR DESCRIPTION
The Team field (`customfield_10001`) can now be set automatically on created Jira issues via the `team` setting in `.jira_sync_config.yaml`. The value should be the team's UUID, which can be found by inspecting an existing Jira issue that has the team set.

Closes #92