### PR TITLE
Support GitHub native issue types

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ settings:
   label_mapping:
     enhancement: Story
 
+  # (Optional) Dictionary mapping GitHub native issue types to Jira issue types.
+  # GitHub issue types (https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization)
+  # are an organization-level classification (e.g. Bug, Feature, Task) that is
+  # distinct from labels. Matching is case-insensitive.
+  # Jira issue type is resolved with the following precedence:
+  #   1. GitHub label mapped via `label_mapping`
+  #   2. GitHub native issue type mapped via `type_mapping`
+  #   3. Default `Bug`
+  # The bot also reacts to the `typed` and `untyped` issue events, so changing an
+  # issue's type in GitHub updates the corresponding Jira issue type.
+  type_mapping:
+    Bug: Bug
+    Feature: Story
+    Task: Task
+
   # (Optional) JIRA issue's summary
   # This field can be used to customize the JIRA issue's summary (title).
   # The value of the field will be passed to the python

--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -62,7 +62,16 @@ gh_synced_label_name = "synced-to-jira"
 with open(Path(__file__).parent / "settings.yaml") as file:
     _file_settings = yaml.safe_load(file)
 
-allowed_gh_actions = ["opened", "edited", "closed", "reopened", "labeled", "unlabeled"]
+allowed_gh_actions = [
+    "opened",
+    "edited",
+    "closed",
+    "reopened",
+    "labeled",
+    "unlabeled",
+    "typed",
+    "untyped",
+]
 
 
 class JSONFormatter(logging.Formatter):
@@ -210,6 +219,37 @@ def _generate_summary(settings: dict, issue: Issue):
             logger.error(msg)
 
     return issue.title
+
+
+def _determine_issue_type(settings: dict, gh_issue_payload: dict, payload_labels: set) -> str:
+    """Determine the Jira issue type to use for a GitHub issue.
+
+    GitHub natively supports issue types (``issue.type``), an organization-level
+    classification (e.g. "Bug", "Feature", "Task") that is distinct from labels.
+
+    Labels can be more specific than the coarse GitHub native types, so they are
+    considered first. The Jira issue type is resolved using the following
+    precedence:
+        1. A GitHub label mapped via ``label_mapping``.
+        2. The GitHub native issue type mapped via ``type_mapping`` (case-insensitive).
+        3. The default ``Bug`` type.
+    """
+    label_mapping = settings.get("label_mapping") or {}
+    for label in payload_labels:
+        if label in label_mapping:
+            return label_mapping[label]
+
+    type_mapping = settings.get("type_mapping") or {}
+    if type_mapping:
+        gh_type = gh_issue_payload.get("type")
+        gh_type_name = gh_type.get("name") if isinstance(gh_type, dict) else None
+        if gh_type_name:
+            lowered_mapping = {str(key).lower(): value for key, value in type_mapping.items()}
+            mapped_type = lowered_mapping.get(gh_type_name.lower())
+            if mapped_type:
+                return mapped_type
+
+    return "Bug"
 
 
 @app.post("/")
@@ -377,12 +417,7 @@ def process_webhook(payload: dict, webhook_id: str = "unknown") -> dict:
         gh_issue_body=issue_body,
     )
 
-    issue_type = "Bug"
-    if settings["label_mapping"]:
-        for label in payload_labels:
-            if label in settings["label_mapping"]:
-                issue_type = settings["label_mapping"][label]
-                break
+    issue_type = _determine_issue_type(settings, payload["issue"], payload_labels)
 
     issue_dict: dict[str, Any] = {
         "project": {"key": settings["jira_project_key"]},
@@ -465,7 +500,7 @@ def process_webhook(payload: dict, webhook_id: str = "unknown") -> dict:
                 }
 
             return {"msg": "No change to Jira Issue labels required"}
-        elif payload["action"] == "edited":
+        elif payload["action"] in ("edited", "typed", "untyped"):
             if settings["components"]:
                 # need to append components to the existing list
                 for component in jira_issue.fields.components:

--- a/github_jira_sync_app/settings.yaml
+++ b/github_jira_sync_app/settings.yaml
@@ -8,6 +8,7 @@ settings:
   epic_key:
   jira_project_key:
   label_mapping:
+  type_mapping:
   status_mapping:
   summary:
   sync_labels: false

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,7 @@ def _default_settings(**overrides):
             "epic_key": None,
             "jira_project_key": "TEST",
             "label_mapping": None,
+            "type_mapping": None,
             "status_mapping": {
                 "opened": "To Do",
                 "closed": "Done",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -248,6 +248,89 @@ class TestCreateNewJiraIssue:
         fields = call_kwargs[1]["fields"]
         assert fields["issuetype"] == {"name": "Defect"}
 
+    def test_create_with_type_mapping(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(type_mapping={"Feature": "Story", "Bug": "Defect"})
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        payload = _get_json("issue_labeled_correct.json")
+        payload["issue"]["type"] = {"name": "Feature"}
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["issuetype"] == {"name": "Story"}
+
+    def test_type_mapping_is_case_insensitive(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(type_mapping={"feature": "Story"})
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        payload = _get_json("issue_labeled_correct.json")
+        payload["issue"]["type"] = {"name": "Feature"}
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["issuetype"] == {"name": "Story"}
+
+    def test_label_mapping_takes_precedence_over_type_mapping(
+        self, signature_mock, mock_github, mock_jira
+    ):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(
+            type_mapping={"Feature": "Story"},
+            label_mapping={"bug": "Defect"},
+        )
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        payload = _get_json("issue_labeled_correct.json")
+        payload["issue"]["type"] = {"name": "Feature"}
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["issuetype"] == {"name": "Defect"}
+
+    def test_falls_back_to_type_mapping_when_label_unmapped(
+        self, signature_mock, mock_github, mock_jira
+    ):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(
+            type_mapping={"Feature": "Story"},
+            label_mapping={"enhancement": "Improvement"},
+        )
+        mock_github.set_config(settings)
+        # Issue label has no mapping configured
+        mock_github.issue.labels = [_make_label("bug")]
+        payload = _get_json("issue_labeled_correct.json")
+        payload["issue"]["type"] = {"name": "Feature"}
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["issuetype"] == {"name": "Story"}
+
+    def test_falls_back_to_bug_when_no_type_or_label_match(
+        self, signature_mock, mock_github, mock_jira
+    ):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(type_mapping={"Feature": "Story"})
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        payload = _get_json("issue_labeled_correct.json")
+        payload["issue"]["type"] = None
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        call_kwargs = mock_jira.client.create_issue.call_args
+        fields = call_kwargs[1]["fields"]
+        assert fields["issuetype"] == {"name": "Bug"}
+
     def test_create_with_custom_summary(self, signature_mock, mock_github, mock_jira):
         from tests.unit.conftest import _default_settings
 
@@ -325,6 +408,40 @@ class TestExistingJiraIssue:
         assert response.status_code == 200
         assert response.json() == {"msg": "Updated existing Jira Issue"}
         mock_jira.existing_issue.update.assert_called_once()
+
+    def test_typed_updates_existing_issue_type(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(type_mapping={"Feature": "Story"})
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        mock_jira.set_existing_issues()
+        payload = _get_json("issue_edited.json")
+        payload["action"] = "typed"
+        payload["issue"]["type"] = {"name": "Feature"}
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        assert response.json() == {"msg": "Updated existing Jira Issue"}
+        call_fields = mock_jira.existing_issue.update.call_args[1]["fields"]
+        assert call_fields["issuetype"] == {"name": "Story"}
+
+    def test_untyped_reverts_existing_issue_type(self, signature_mock, mock_github, mock_jira):
+        from tests.unit.conftest import _default_settings
+
+        settings = _default_settings(
+            type_mapping={"Feature": "Story"}, label_mapping={"bug": "Defect"}
+        )
+        mock_github.set_config(settings)
+        mock_github.issue.labels = [_make_label("bug")]
+        mock_jira.set_existing_issues()
+        payload = _get_json("issue_edited.json")
+        payload["action"] = "untyped"
+        payload["issue"]["type"] = None
+        response = client.post("/", json=payload)
+        assert response.status_code == 200
+        assert response.json() == {"msg": "Updated existing Jira Issue"}
+        call_fields = mock_jira.existing_issue.update.call_args[1]["fields"]
+        assert call_fields["issuetype"] == {"name": "Defect"}
 
     def test_edit_existing_issue_appends_components(self, signature_mock, mock_github, mock_jira):
         from tests.unit.conftest import _default_settings


### PR DESCRIPTION
Add a `type_mapping` config that maps GitHub native issue types (issue.type) to Jira issue types. The Jira issue type is resolved with the precedence: label_mapping, then type_mapping (case-insensitive), then the default Bug. Also handle the `typed` and `untyped` issue events so changing an issue's type in GitHub updates the Jira issue type.

UDENG-10834