### PR TITLE
Reduce Jira round trips on webhook critical path

### DIFF
--- a/github_jira_sync_app/main.py
+++ b/github_jira_sync_app/main.py
@@ -361,6 +361,8 @@ def process_webhook(payload: dict, webhook_id: str = "unknown") -> dict:
     existing_issues = jira.enhanced_search_issues(
         rf'project="{settings["jira_project_key"]}" AND '
         + rf'description ~"{jira_task_desc_match}"',
+        fields="labels,components",
+        maxResults=1,
         json_result=False,
     )
     assert isinstance(existing_issues, list), "Jira did not return a list of existing issues"
@@ -424,7 +426,7 @@ def process_webhook(payload: dict, webhook_id: str = "unknown") -> dict:
         if payload["action"] == "closed":
             return {"msg": "Issue in Jira doesn't exist and GitHub issue was closed. Ignoring."}
 
-        new_issue = jira.create_issue(fields=issue_dict)
+        new_issue = jira.create_issue(fields=issue_dict, prefetch=False)
         existing_issues.append(new_issue)
 
         if settings.get("add_gh_synced_label", False):

--- a/tests/unit/test_webhook_timeout.py
+++ b/tests/unit/test_webhook_timeout.py
@@ -1,0 +1,48 @@
+import json
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from fastapi.testclient import TestClient
+
+UNITTESTS_DIR = Path(__file__).parent
+load_dotenv(UNITTESTS_DIR / "dumm_env", verbose=True)
+assert os.environ["JIRA_INSTANCE"]
+
+# import only after we set dummy environment
+from github_jira_sync_app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def _get_json(file_name):
+    with open(UNITTESTS_DIR / "payloads" / file_name) as file:
+        return json.load(file)
+
+
+def _post_new_issue(mock_github):
+    label = type("Label", (), {"name": "bug"})()
+    mock_github.issue.labels = [label]
+    return client.post("/", json=_get_json("issue_labeled_correct.json"))
+
+
+def test_new_issue_creation_disables_jira_prefetch(
+    signature_mock, mock_github, mock_jira
+):
+    """Avoid Jira's automatic follow-up GET after a successful issue POST."""
+    response = _post_new_issue(mock_github)
+
+    assert response.status_code == 200
+    assert "Issue was created in Jira" in response.json()["msg"]
+    assert mock_jira.client.create_issue.call_count == 1
+    assert mock_jira.client.create_issue.call_args.kwargs["prefetch"] is False
+
+
+def test_duplicate_lookup_is_bounded(signature_mock, mock_github, mock_jira):
+    """Fetch only the first Jira match and fields used by update paths."""
+    response = _post_new_issue(mock_github)
+
+    assert response.status_code == 200
+    lookup = mock_jira.client.enhanced_search_issues.call_args
+    assert lookup.kwargs["maxResults"] == 1
+    assert lookup.kwargs["fields"] == "labels,components"


### PR DESCRIPTION
Relates to #56.

This keeps Jira card creation on the synchronous webhook path, preserving the issue author’s safety constraint that the bot should not acknowledge success before the Jira card exists.

The branch removes two avoidable sources of latency from that critical path:

* bounds the duplicate Jira lookup to one result and requests only the labels and components fields used by existing update paths;
* disables jira-python’s automatic post-create issue reload with create_issue(..., prefetch=False).

Regression tests cover both behaviours.

I also investigated disabling Jira server-info discovery, but rejected that change because enhanced_search_issues is Jira-Cloud-only and depends on the client identifying the deployment type. Keeping normal client initialisation preserves the existing Cloud search path.

This does not claim that a Jira create POST which itself takes more than GitHub’s 10-second webhook deadline can be made safe without changing the acknowledgement model. The patch targets avoidable latency around creation while preserving existing semantics.

AI assistance was used during investigation and test drafting; the changes were reviewed against the repository’s pinned jira-python 3.10.5 behaviour and existing webhook flow.